### PR TITLE
fix blocking file.type verif

### DIFF
--- a/js/common/components/file-loader.js
+++ b/js/common/components/file-loader.js
@@ -136,14 +136,6 @@ FileLoader.prototype.checkErrors = function (files) {
         );
         return;
     }
-    // file type
-    if (file.type !== 'application/json') {
-        $.notify(
-            'File is expected to have a JSON media type',
-            "warn"
-        );
-        return;
-    }
 
     return true;// success
 };


### PR DESCRIPTION
On my environment  : chrome Version 48.0.2564.116 m, windows 8.1
The file.type is empty so I can't upload file.
